### PR TITLE
Update location to Mumbai, India in Footer and Contact page

### DIFF
--- a/src/components/layout/Footer.js
+++ b/src/components/layout/Footer.js
@@ -93,7 +93,7 @@ export default function Footer() {
               </div>
               <div className="flex items-center gap-3 text-sm text-gray-300">
                 <MapPin className="w-4 h-4 text-primary-400" />
-                San Francisco, CA
+                Mumbai, India
               </div>
             </div>
           </div>

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -236,8 +236,8 @@ export default function Contact() {
                       <h4 className="font-semibold text-gray-900">Office</h4>
                       <p className="text-gray-600">
                         123 Innovation Drive<br />
-                        San Francisco, CA 94105<br />
-                        United States
+                        Mumbai, Maharashtra 400001<br />
+                        India
                       </p>
                     </div>
                   </div>


### PR DESCRIPTION
I updated the company's address from San Francisco to India across the codebase.

Specifically, I made the following changes:

*   In `src/pages/contact.js`, I modified the detailed office address on line 238 from "123 Innovation Drive, San Francisco, CA 94105, United States" to "123 Innovation Drive, Mumbai, Maharashtra 400001, India". This ensures the primary contact page reflects the new location with a full Indian address.
*   In `src/components/layout/Footer.js`, I updated the location displayed in the footer on line 95 from "San Francisco, CA" to "Mumbai, India". This provides a consistent, concise location update across the site's footer.

These changes ensure the website now consistently displays the company's address as being located in Mumbai, India.